### PR TITLE
Fix unicode issues

### DIFF
--- a/app/api_1_0/errors.py
+++ b/app/api_1_0/errors.py
@@ -12,14 +12,14 @@ def redirecting(exception):
 @api_1_0.app_errorhandler(400)
 def bad_request(exception):
     response = {'status: ': 400, 'message: ': 'Bad request: ' + request.url}
-    response['reason'] = exception
+    response['reason'] = unicode(exception)
     response = jsonify(response)
     response.status_code = 400
     return response
 
 def unauthorized(exception):
     response = {'status: ': 401, 'message: ': 'Unauthorized: ' + request.url}
-    response['reason'] = exception
+    response['reason'] = unicode(exception)
     response = jsonify(response)
     response.status_code = 401
     return response

--- a/app/api_1_0/smstools.py
+++ b/app/api_1_0/smstools.py
@@ -79,7 +79,7 @@ def send_sms(data):
     text, coding, parts_count = detect_coding(data['text'])
 
     result = {
-        'sent_text': text,
+        'sent_text': data['text'],
         'parts_count': parts_count,
         'mobiles': {}
     }


### PR DESCRIPTION
We have run into some issues with following SMS contents:

```
NTK: Na Centralnim pultu v 2. NP mate pripravenou k vyzvednuti objednanou publikaci Official (ISC)2® guide to the CISSP® CBK® / edited by Adam Gordon
```

First, we needed to stop trying to JSON-encode an `Exception` and next, we fixed the actual issue of double-encoding the `response` payload.
